### PR TITLE
Proposal for map2i and map2

### DIFF
--- a/examples/test_dense.ml
+++ b/examples/test_dense.ml
@@ -25,6 +25,8 @@ let _ =
   test_op "rows       " c (fun () -> M.rows x [|1;2|]);
   test_op "map        " c (fun () -> M.map (fun y -> 0.) x);
   test_op "mapi       " c (fun () -> M.mapi (fun _ _ y -> 0.) x);
+  test_op "map2       " c (fun () -> M.map2 (fun _ _ -> 0.) x x);
+  test_op "map2i      " c (fun () -> M.map2i (fun _ _ _ _ -> 0.) x x);
   test_op "iter       " c (fun () -> M.iter (fun y -> 0.) x);
   test_op "iteri      " c (fun () -> M.iteri (fun _ _ y -> 0.) x);
   test_op "iter_cols  " c (fun () -> M.iter_cols (fun y -> ()) x);

--- a/lib/dense.ml
+++ b/lib/dense.ml
@@ -239,6 +239,15 @@ let mapi_by_col ?(d=0) f x =
 
 let map_by_col ?(d=0) f x = mapi_by_col ~d (fun _ y -> f y) x
 
+let map2i f x y =
+  if row_num x = row_num y && col_num x = col_num y then
+    let z = empty (row_num x) (col_num x) in
+    iteri (fun i j w -> Array2.unsafe_set z i j (f i j w)) x; y
+  else
+    raise (Invalid_argument "map2ij: dimensions do not match")
+
+let map2 f x y = mapi (fun _ _ w -> f w) x
+
 let filteri f x =
   let r = ref [||] in
   iteri (fun i j y ->

--- a/lib/dense.ml
+++ b/lib/dense.ml
@@ -242,11 +242,17 @@ let map_by_col ?(d=0) f x = mapi_by_col ~d (fun _ y -> f y) x
 let map2i f x y =
   if row_num x = row_num y && col_num x = col_num y then
     let z = empty (row_num x) (col_num x) in
-    iteri (fun i j w -> Array2.unsafe_set z i j (f i j w)) x; y
+    iteri
+      (fun i j vx ->
+        let vy = Array2.unsafe_get y i j in
+        Array2.unsafe_set z i j (f i j vx vy)
+      )
+      x;
+    y
   else
     raise (Invalid_argument "map2ij: dimensions do not match")
 
-let map2 f x y = mapi (fun _ _ w -> f w) x
+let map2 f x y = map2i (fun _ _ vx vy -> f vx vy) x y
 
 let filteri f x =
   let r = ref [||] in

--- a/lib/dense.mli
+++ b/lib/dense.mli
@@ -229,6 +229,19 @@ val map : (float -> float) -> dsmat -> dsmat
   current element is not passed to the function [f : float -> float]
  *)
 
+val map2i : (int -> int -> float -> float -> float) -> dsmat -> dsmat -> dsmat
+(** [map2i f x y] maps each pointwise pair of elements in [x] and [y] to a
+  new value by applying [f : int -> int -> float -> float -> float]. The
+  first two parameters are the coordinates of the elements, and the third
+  and fourth parameters are the values.
+ *)
+
+val map2 : (float -> float -> float) -> dsmat -> dsmat -> dsmat
+(** [map2 f x y] is similar to [map2i f x y] except the coordinates of the
+  current element is not passed to the function [f : float -> float -> float]
+ *)
+
+
 val fold : ('a -> float -> 'a) -> 'a -> dsmat -> 'a
 (** [fold f a x] folds all the elements in [x] with the function
   [f : 'a -> float -> 'a]. For an [m] by [n] matrix [x], the order of folding


### PR DESCRIPTION
Here's a quick implementation of `map2i` and `map2`. There are a few things that might need to change:
- Error management: the error when the number of columns or lines don't match should be similar to other functions with the same requirements (e.g., `add`).
- More functions: there is a collection of `map` functions (by row, by col, etc.) that should be available in `2` flavour.

In general, libraries that implement `map`-like and `map2`-like operations provide optimised versions up to a given number and then a generic one that is less efficient. Not sure you want a similar thing here.
