### PR TITLE
fix image plot bug

### DIFF
--- a/lib/owl_plot.ml
+++ b/lib/owl_plot.ml
@@ -1596,17 +1596,19 @@ let scatterhist = None
 let image ?(h=_default_handle) x =
   let open Plplot in
   (* compute necessary parameters *)
-  let width, height = Owl_dense_matrix.D.shape x in
+  let height, width = Owl_dense_matrix.D.shape x in
   let num_col = Owl_dense_matrix.D.max x in
-  let img = Owl_dense_matrix.D.to_arrays x in
+  let img = x |> Owl_dense_matrix.D.transpose
+              |> Owl_dense_matrix.D.to_arrays
+  in
   let width = float_of_int width in
   let height = float_of_int height in
   let num_col = int_of_float num_col in
   (* specify the boundary of imageplot *)
-  let x = [|1.0; width|]  in
-  let y = [|1.0; height|] in
-  _adjust_range h x X;
-  _adjust_range h y Y;
+  let xlim = [|1.0; width|]  in
+  let ylim = [|1.0; height|] in
+  _adjust_range h xlim X;
+  _adjust_range h ylim Y;
   (* keep the scale of original image instead of 4:3 *)
   h.page_size <- (int_of_float width, int_of_float height);
   (* prepare the closure *)

--- a/lib/owl_plot.mli
+++ b/lib/owl_plot.mli
@@ -310,5 +310,5 @@ val qqplot : ?h:handle -> ?spec:spec list -> ?pd:(float -> float) -> ?x:dsmat ->
 
 val image : ?h:handle -> dsmat -> unit
 (**
-  [image x] display a m * n matrix [x] xas image. Each element in the matrix is of range 0 ~ 255.
+  [image x] display a [m x n] matrix [x] as image. Each element in the matrix is of range 0 ~ 255.
  *)

--- a/lib/owl_plot.mli
+++ b/lib/owl_plot.mli
@@ -310,5 +310,5 @@ val qqplot : ?h:handle -> ?spec:spec list -> ?pd:(float -> float) -> ?x:dsmat ->
 
 val image : ?h:handle -> dsmat -> unit
 (**
-  [image mat] display a m * n matrix as image. Each element in the matrix is of range 0 ~ 255.
+  [image x] display a m * n matrix [x] xas image. Each element in the matrix is of range 0 ~ 255.
  *)


### PR DESCRIPTION
Thank for pointing out this problem. As you may have found out, the input matrix need to be transposed to be positioned correctly. I will also update/rotate the example file `durer.txt` (which is actually now a 600 * 900 matrix) accordingly.