### PR TITLE
fix image-flip bug of imageplot

### DIFF
--- a/lib/owl_plot.ml
+++ b/lib/owl_plot.ml
@@ -1593,14 +1593,24 @@ let scatterhist = None
 
 (* other plots *)
 
+let _rotate270_ x =
+  let w, h = Owl_dense_matrix.D.shape x in
+  let mat = Owl_dense_matrix.D.zeros h w in
+  for i = 0 to w - 1 do
+    for j = 0 to h - 1 do
+      Owl_dense_matrix.D.set mat j (w - 1 - i) (Owl_dense_matrix.D.get x i j)
+    done
+  done;
+  mat
+
 let image ?(h=_default_handle) x =
   let open Plplot in
+  (* rotate the matrix 90 degree clockwise to be shown correctly as image *)
+  let x = _rotate270_ x in
   (* compute necessary parameters *)
-  let height, width = Owl_dense_matrix.D.shape x in
+  let width, height = Owl_dense_matrix.D.shape x in
   let num_col = Owl_dense_matrix.D.max x in
-  let img = x |> Owl_dense_matrix.D.transpose
-              |> Owl_dense_matrix.D.to_arrays
-  in
+  let img = Owl_dense_matrix.D.to_arrays x in
   let width = float_of_int width in
   let height = float_of_int height in
   let num_col = int_of_float num_col in


### PR DESCRIPTION
So sorry for the untested PR.  Here is how I propose to fix this problem and why:

If we `image` the input matrix as is, it will recognise the top left corner of the matrix as origin, with x-axis along rows and y-axis along columns, which is exactly how a matrix locate its elements. So I rotate the input matrix 90 degree clockwise (I failed to find a `Mat.rotate` or similar function from the doc so just implement a simple one) and then plot it as image.   I test with the code:

```ocaml
let z0 = Mat.create 100 100 200. in
let z1 = Mat.zeros 100 100 in
let z = Mat.((z1 @|| z0) @= (z1 @|| z1) @= (z1 @|| z1)) in
Plot.image z
```

The white rectangle (though not a square as we expected  --- I'll look into this problem later) is correctly shown on the upper left corner.