### PR TITLE
Fixing `l2norm` for complex arrays

### DIFF
--- a/lib/owl_dense_common_c.c
+++ b/lib/owl_dense_common_c.c
@@ -884,14 +884,14 @@ value cp_two_doubles(double d0, double d1)
 #define FUN5 complex_float_l2norm_sqr
 #define INIT float r = 0.
 #define NUMBER complex_float
-#define ACCFN(A,X) (A += X.r * X.r - X.i * X.i + 2 * X.r * X.i)
+#define ACCFN(A,X) (A += X.r * X.r + X.i * X.i)
 #define COPYNUM(X) (caml_copy_double(X))
 #include "owl_dense_common_vec_fold.c"
 
 #define FUN5 complex_double_l2norm_sqr
 #define INIT double r = 0.
 #define NUMBER complex_double
-#define ACCFN(A,X) (A += X.r * X.r - X.i * X.i + 2 * X.r * X.i)
+#define ACCFN(A,X) (A += X.r * X.r + X.i * X.i)
 #define COPYNUM(X) (caml_copy_double(X))
 #include "owl_dense_common_vec_fold.c"
 

--- a/unittest/unit_dense_ndarray.ml
+++ b/unittest/unit_dense_ndarray.ml
@@ -26,6 +26,11 @@ let _ =
   M.set x2 [|0;1;1|] 3.;
   M.set x2 [|1;0;0|] 7.
 
+let vec = M.zeros Complex32 [|2;1|]
+let _ =
+   M.set vec [|0;0|] {Complex.re=0.0;im=3.0};
+   M.set vec [|1;0|] {Complex.re=0.0;im=(-4.0)}
+
 (* a module with functions to test *)
 module To_test = struct
 
@@ -130,6 +135,8 @@ module To_test = struct
   let flatten () = M.get (M.flatten x0) [|3|] = 2.
 
   let reshape () = M.get (M.reshape x0 [|2;3;2|]) [|0;1;1|] = 2.
+
+  let l2norm () = M.l2norm vec = 5.
 
   let save_load () =
     M.save x0 "ds_nda.tmp";
@@ -257,6 +264,9 @@ let flatten () =
 let reshape () =
   Alcotest.(check bool) "reshape" true (To_test.reshape ())
 
+let l2norm () =
+  Alcotest.(check bool) "l2norm" true (To_test.l2norm ())
+
 let save_load () =
   Alcotest.(check bool) "save_load" true (To_test.save_load ())
 
@@ -300,5 +310,6 @@ let test_set = [
   "transpose", `Slow, transpose;
   "flatten", `Slow, flatten;
   "reshape", `Slow, reshape;
+  "l2norm", `Slow, l2norm;
   "save_load", `Slow, save_load;
 ]


### PR DESCRIPTION
When calculating the squared L2 norm of complex vectors the result can be negative giving rise to `NaN` when taking the `sqrt`. L2 norms are positive-semidefinite at all times. This fix adjusts the accumulator function for the L2 norm of complex numbers.

* Adjust accumulator for complex numbers
* Add unit test for complex vector