### PR TITLE
Fixed module paths to Gsl.Fft

### DIFF
--- a/lib/owl_fft.ml
+++ b/lib/owl_fft.ml
@@ -16,9 +16,9 @@ let _fft_real_rad2 x =
   let y = Owl_dense_matrix_z.empty m n in
   Owl_dense_matrix_d.iteri_rows (fun i v ->
     let v = Owl_dense_matrix_d.to_array v in
-    let z = Gsl_fft.({ layout = Real; data = v }) in
-    Gsl_fft.Real.transform_rad2 z;
-    let d = Gsl_fft.unpack z in
+    let z = Gsl.Fft.({ layout = Real; data = v }) in
+    Gsl.Fft.Real.transform_rad2 z;
+    let d = Gsl.Fft.unpack z in
     for j = 0 to n - 1 do
       let k = 2 * j in
       let re, im = d.(k), d.(k + 1) in
@@ -30,13 +30,13 @@ let _fft_real_rad2 x =
 let _fft_real_radn x =
   let m, n = Owl_dense_matrix_d.shape x in
   let y = Owl_dense_matrix_z.empty m n in
-  let w0 = Gsl_fft.Real.make_wavetable n in
-  let w1 = Gsl_fft.Real.make_workspace n in
+  let w0 = Gsl.Fft.Real.make_wavetable n in
+  let w1 = Gsl.Fft.Real.make_workspace n in
   Owl_dense_matrix_d.iteri_rows (fun i v ->
     let v = Owl_dense_matrix_d.to_array v in
-    let z = Gsl_fft.({ layout = Real; data = v }) in
-    Gsl_fft.Real.transform z w0 w1;
-    let d = Gsl_fft.unpack z in
+    let z = Gsl.Fft.({ layout = Real; data = v }) in
+    Gsl.Fft.Real.transform z w0 w1;
+    let d = Gsl.Fft.unpack z in
     for j = 0 to n - 1 do
       let k = 2 * j in
       let re, im = d.(k), d.(k + 1) in
@@ -61,7 +61,7 @@ let _fft_complex_inv_rad2 x =
       v.(p) <- Complex.(c.re);
       v.(p + 1) <- Complex.(c.im);
     ) u;
-    Gsl_fft.Complex.inverse_rad2 v;
+    Gsl.Fft.Complex.inverse_rad2 v;
     for j = 0 to n - 1 do
       let k = 2 * j in
       let re, im = v.(k), v.(k + 1) in
@@ -74,15 +74,15 @@ let _fft_complex_inv_radn x =
   let m, n = Owl_dense_matrix_z.shape x in
   let y = Owl_dense_matrix_z.empty m n in
   let v = Array.make (2 * n) 0. in
-  let w0 = Gsl_fft.Complex.make_wavetable n in
-  let w1 = Gsl_fft.Complex.make_workspace n in
+  let w0 = Gsl.Fft.Complex.make_wavetable n in
+  let w1 = Gsl.Fft.Complex.make_workspace n in
   Owl_dense_matrix_z.iteri_rows (fun i u ->
     Owl_dense_matrix_z.iteri (fun _ q c ->
       let p = 2 * q in
       v.(p) <- Complex.(c.re);
       v.(p + 1) <- Complex.(c.im);
     ) u;
-    Gsl_fft.Complex.inverse v w0 w1;
+    Gsl.Fft.Complex.inverse v w0 w1;
     for j = 0 to n - 1 do
       let k = 2 * j in
       let re, im = v.(k), v.(k + 1) in
@@ -107,7 +107,7 @@ let _fft_complex_rad2 x =
       v.(p) <- Complex.(c.re);
       v.(p + 1) <- Complex.(c.im);
     ) u;
-    Gsl_fft.Complex.forward_rad2 v;
+    Gsl.Fft.Complex.forward_rad2 v;
     for j = 0 to n - 1 do
       let k = 2 * j in
       let re, im = v.(k), v.(k + 1) in
@@ -120,15 +120,15 @@ let _fft_complex_radn x =
   let m, n = Owl_dense_matrix_z.shape x in
   let y = Owl_dense_matrix_z.empty m n in
   let v = Array.make (2 * n) 0. in
-  let w0 = Gsl_fft.Complex.make_wavetable n in
-  let w1 = Gsl_fft.Complex.make_workspace n in
+  let w0 = Gsl.Fft.Complex.make_wavetable n in
+  let w1 = Gsl.Fft.Complex.make_workspace n in
   Owl_dense_matrix_z.iteri_rows (fun i u ->
     Owl_dense_matrix_z.iteri (fun _ q c ->
       let p = 2 * q in
       v.(p) <- Complex.(c.re);
       v.(p + 1) <- Complex.(c.im);
     ) u;
-    Gsl_fft.Complex.forward v w0 w1;
+    Gsl.Fft.Complex.forward v w0 w1;
     for j = 0 to n - 1 do
       let k = 2 * j in
       let re, im = v.(k), v.(k + 1) in


### PR DESCRIPTION
The latest GSL release packages the library differently (using `jbuilder`), making it incompatible with Owl.  `Gsl_fft` was never supposed to be accessible, but leaked through anyway.  The correct way is to always use `Gsl.?` for accessing parts of the packed library.