### PR TITLE
added draw_polygon

### DIFF
--- a/src/owl/owl_plot.ml
+++ b/src/owl/owl_plot.ml
@@ -1011,75 +1011,51 @@ let bar ?(h=_default_handle) ?(spec=[]) y =
   if not h.holdon then output h
 
 
-let area ?(h=_default_handle) ?(spec=[]) x y=
+let _area_fill h spec x y =
   let open Plplot in
+  _adjust_range h x X;
+  _adjust_range h y Y;
+  (* prepare the closure *)
+  let p = h.pages.(h.current_page) in
+  let color = _get_rgb spec p.fgcolor in
+  let r, g, b = color in
+  let line_style = _get_line_style spec 1 in
+  let fill_pattern = _get_fill_pattern spec 0 in
+  (* drawing function *)
+  let f = (fun () ->
+    let r', g', b' = plgcol0 1 in
+    plscol0 1 r g b;
+    plcol0 1;
+    pllsty line_style;
+    plline x y;
+    plpsty fill_pattern;
+    plfill x y;
+    (* restore original settings *)
+    plscol0 1 r' g' b';
+    plcol0 1;
+    pllsty 1
+  )
+  in
+  (* add closure as a layer *)
+  p.plots <- Array.append p.plots [|f|];
+  (* add legend item to page *)
+  _add_legend_item p BOX line_style color "" color fill_pattern color;
+  if not h.holdon then output h
+
+
+let area ?(h=_default_handle) ?(spec=[]) x y =
   let x = Owl_dense_matrix.D.to_array x in
   let y = Owl_dense_matrix.D.to_array y in
   let xmin, xmax = Owl_stats.minmax x in
   let x = Array.(append (append [|xmin|] x) [|xmax|]) in
   let y = Array.(append (append [|0.|] y) [|0.|]) in
-  _adjust_range h x X;
-  _adjust_range h y Y;
-  (* prepare the closure *)
-  let p = h.pages.(h.current_page) in
-  let color = _get_rgb spec p.fgcolor in
-  let r, g, b = color in
-  let line_style = _get_line_style spec 1 in
-  let fill_pattern = _get_fill_pattern spec 0 in
-  (* drawing function *)
-  let f = (fun () ->
-    let r', g', b' = plgcol0 1 in
-    plscol0 1 r g b;
-    plcol0 1;
-    pllsty line_style;
-    plline x y;
-    plpsty fill_pattern;
-    plfill x y;
-    (* restore original settings *)
-    plscol0 1 r' g' b';
-    plcol0 1;
-    pllsty 1
-  )
-  in
-  (* add closure as a layer *)
-  p.plots <- Array.append p.plots [|f|];
-  (* add legend item to page *)
-  _add_legend_item p BOX line_style color "" color fill_pattern color;
-  if not h.holdon then output h
+  _area_fill h spec x y
 
 
 let draw_polygon ?(h=_default_handle) ?(spec=[]) x y =
-  let open Plplot in
   let x = Owl_dense_matrix.D.to_array x in
   let y = Owl_dense_matrix.D.to_array y in
-  _adjust_range h x X;
-  _adjust_range h y Y;
-  (* prepare the closure *)
-  let p = h.pages.(h.current_page) in
-  let color = _get_rgb spec p.fgcolor in
-  let r, g, b = color in
-  let line_style = _get_line_style spec 1 in
-  let fill_pattern = _get_fill_pattern spec 0 in
-  (* drawing function *)
-  let f = (fun () ->
-    let r', g', b' = plgcol0 1 in
-    plscol0 1 r g b;
-    plcol0 1;
-    pllsty line_style;
-    plline x y;
-    plpsty fill_pattern;
-    plfill x y;
-    (* restore original settings *)
-    plscol0 1 r' g' b';
-    plcol0 1;
-    pllsty 1
-  )
-  in
-  (* add closure as a layer *)
-  p.plots <- Array.append p.plots [|f|];
-  (* add legend item to page *)
-  _add_legend_item p BOX line_style color "" color fill_pattern color;
-  if not h.holdon then output h
+  _area_fill h spec x y
 
 let _ecdf_interleave x i =
   let m = Array.length x in

--- a/src/owl/owl_plot.ml
+++ b/src/owl/owl_plot.ml
@@ -1011,8 +1011,13 @@ let bar ?(h=_default_handle) ?(spec=[]) y =
   if not h.holdon then output h
 
 
-let _area_fill h spec x y =
+let area ?(h=_default_handle) ?(spec=[]) x y=
   let open Plplot in
+  let x = Owl_dense_matrix.D.to_array x in
+  let y = Owl_dense_matrix.D.to_array y in
+  let xmin, xmax = Owl_stats.minmax x in
+  let x = Array.(append (append [|xmin|] x) [|xmax|]) in
+  let y = Array.(append (append [|0.|] y) [|0.|]) in
   _adjust_range h x X;
   _adjust_range h y Y;
   (* prepare the closure *)
@@ -1043,19 +1048,38 @@ let _area_fill h spec x y =
   if not h.holdon then output h
 
 
-let area ?(h=_default_handle) ?(spec=[]) x y =
-  let x = Owl_dense_matrix.D.to_array x in
-  let y = Owl_dense_matrix.D.to_array y in
-  let xmin, xmax = Owl_stats.minmax x in
-  let x = Array.(append (append [|xmin|] x) [|xmax|]) in
-  let y = Array.(append (append [|0.|] y) [|0.|]) in
-  _area_fill h spec x y
-
-
 let draw_polygon ?(h=_default_handle) ?(spec=[]) x y =
+  let open Plplot in
   let x = Owl_dense_matrix.D.to_array x in
   let y = Owl_dense_matrix.D.to_array y in
-  _area_fill h spec x y
+  _adjust_range h x X;
+  _adjust_range h y Y;
+  (* prepare the closure *)
+  let p = h.pages.(h.current_page) in
+  let color = _get_rgb spec p.fgcolor in
+  let r, g, b = color in
+  let line_style = _get_line_style spec 1 in
+  let fill_pattern = _get_fill_pattern spec 0 in
+  (* drawing function *)
+  let f = (fun () ->
+    let r', g', b' = plgcol0 1 in
+    plscol0 1 r g b;
+    plcol0 1;
+    pllsty line_style;
+    plline x y;
+    plpsty fill_pattern;
+    plfill x y;
+    (* restore original settings *)
+    plscol0 1 r' g' b';
+    plcol0 1;
+    pllsty 1
+  )
+  in
+  (* add closure as a layer *)
+  p.plots <- Array.append p.plots [|f|];
+  (* add legend item to page *)
+  _add_legend_item p BOX line_style color "" color fill_pattern color;
+  if not h.holdon then output h
 
 let _ecdf_interleave x i =
   let m = Array.length x in

--- a/src/owl/owl_plot.ml
+++ b/src/owl/owl_plot.ml
@@ -1048,6 +1048,39 @@ let area ?(h=_default_handle) ?(spec=[]) x y=
   if not h.holdon then output h
 
 
+let draw_polygon ?(h=_default_handle) ?(spec=[]) x y =
+  let open Plplot in
+  let x = Owl_dense_matrix.D.to_array x in
+  let y = Owl_dense_matrix.D.to_array y in
+  _adjust_range h x X;
+  _adjust_range h y Y;
+  (* prepare the closure *)
+  let p = h.pages.(h.current_page) in
+  let color = _get_rgb spec p.fgcolor in
+  let r, g, b = color in
+  let line_style = _get_line_style spec 1 in
+  let fill_pattern = _get_fill_pattern spec 0 in
+  (* drawing function *)
+  let f = (fun () ->
+    let r', g', b' = plgcol0 1 in
+    plscol0 1 r g b;
+    plcol0 1;
+    pllsty line_style;
+    plline x y;
+    plpsty fill_pattern;
+    plfill x y;
+    (* restore original settings *)
+    plscol0 1 r' g' b';
+    plcol0 1;
+    pllsty 1
+  )
+  in
+  (* add closure as a layer *)
+  p.plots <- Array.append p.plots [|f|];
+  (* add legend item to page *)
+  _add_legend_item p BOX line_style color "" color fill_pattern color;
+  if not h.holdon then output h
+
 let _ecdf_interleave x i =
   let m = Array.length x in
   let n = 2 * m in

--- a/src/owl/owl_plot.mli
+++ b/src/owl/owl_plot.mli
@@ -176,6 +176,14 @@ val area : ?h:handle -> ?spec:spec list -> dsmat -> dsmat -> unit
   Parameters: [RGB], [LineStyle], [FillPattern].
  *)
 
+val draw_polygon : ?h:handle -> ?spec:spec list -> dsmat -> dsmat -> unit
+(** [area x y] fills the polygon specified by [x] and [y].  Each point
+  will be treated as connected to the next point except the last, which 
+  will be connected to the first point.
+
+  Parameters: [RGB], [LineStyle], [FillPattern].
+ *)
+
 val error_bar : ?h:handle -> ?spec:spec list -> dsmat -> dsmat -> dsmat -> unit
 (** [error_bar x y] generates a line plot of [x] and [y] with error bars.
 


### PR DESCRIPTION
Identical to `area` but with four lines deleted, and a new doc comment.

I think I'm going to try also doing a second PR that's the same but that pulls out the code that `area` and `draw_polygon` into an internal function.  If github will allow two separate PRs (??), then you can choose.

(I understand the value of having different functions that duplicate code.  It's simpler to understand, and if you want to change one but not the other, it's easier.  However, in this case `draw_polygon` really is `area` with four lines deleted, so maybe it's reasonable to have them call the same internal function to run the code that's the same in both functions.)

This is in response to #107.