### PR TITLE
Fix bug in plot, loglog: let within if was capturing rest of closure

### DIFF
--- a/src/owl/owl_plot.ml
+++ b/src/owl/owl_plot.ml
@@ -640,9 +640,10 @@ let plot ?(h=_default_handle) ?(spec=[]) x y =
     plschr marker_size 1.;
     if line_style > 0 && line_style < 9 then
       pllsty line_style; plline x y;
-    if marker <> "" then
+    if marker <> "" then (
       let x', y' = _thinning x, _thinning y in
-      plstring x' y' marker;
+      plstring x' y' marker
+    );
     (* restore original settings *)
     plschr c' 1.;
     plwidth old_pensize;
@@ -1259,9 +1260,10 @@ let loglog ?(h=_default_handle) ?(spec=[]) ?x y =
     plschr marker_size 1.;
     if line_style > 0 && line_style < 9 then
       pllsty line_style; plline x y;
-    if marker <> "" then
+    if marker <> "" then (
       let x', y' = _thinning x, _thinning y in
-      plstring x' y' marker;
+      plstring x' y' marker
+    );
     (* restore original settings *)
     plschr c' 1.;
     plwidth old_pensize;

--- a/src/owl/owl_plot.ml
+++ b/src/owl/owl_plot.ml
@@ -1011,75 +1011,51 @@ let bar ?(h=_default_handle) ?(spec=[]) y =
   if not h.holdon then output h
 
 
-let area ?(h=_default_handle) ?(spec=[]) x y=
+let _area_fill h spec x y =
   let open Plplot in
+  _adjust_range h x X;
+  _adjust_range h y Y;
+  (* prepare the closure *)
+  let p = h.pages.(h.current_page) in
+  let color = _get_rgb spec p.fgcolor in
+  let r, g, b = color in
+  let line_style = _get_line_style spec 1 in
+  let fill_pattern = _get_fill_pattern spec 0 in
+  (* drawing function *)
+  let f = (fun () ->
+    let r', g', b' = plgcol0 1 in
+    plscol0 1 r g b;
+    plcol0 1;
+    pllsty line_style;
+    plline x y;
+    plpsty fill_pattern;
+    plfill x y;
+    (* restore original settings *)
+    plscol0 1 r' g' b';
+    plcol0 1;
+    pllsty 1
+  )
+  in
+  (* add closure as a layer *)
+  p.plots <- Array.append p.plots [|f|];
+  (* add legend item to page *)
+  _add_legend_item p BOX line_style color "" color fill_pattern color;
+  if not h.holdon then output h
+
+
+let area ?(h=_default_handle) ?(spec=[]) x y =
   let x = Owl_dense_matrix.D.to_array x in
   let y = Owl_dense_matrix.D.to_array y in
   let xmin, xmax = Owl_stats.minmax x in
   let x = Array.(append (append [|xmin|] x) [|xmax|]) in
   let y = Array.(append (append [|0.|] y) [|0.|]) in
-  _adjust_range h x X;
-  _adjust_range h y Y;
-  (* prepare the closure *)
-  let p = h.pages.(h.current_page) in
-  let color = _get_rgb spec p.fgcolor in
-  let r, g, b = color in
-  let line_style = _get_line_style spec 1 in
-  let fill_pattern = _get_fill_pattern spec 0 in
-  (* drawing function *)
-  let f = (fun () ->
-    let r', g', b' = plgcol0 1 in
-    plscol0 1 r g b;
-    plcol0 1;
-    pllsty line_style;
-    plline x y;
-    plpsty fill_pattern;
-    plfill x y;
-    (* restore original settings *)
-    plscol0 1 r' g' b';
-    plcol0 1;
-    pllsty 1
-  )
-  in
-  (* add closure as a layer *)
-  p.plots <- Array.append p.plots [|f|];
-  (* add legend item to page *)
-  _add_legend_item p BOX line_style color "" color fill_pattern color;
-  if not h.holdon then output h
+  _area_fill h spec x y
 
 
 let draw_polygon ?(h=_default_handle) ?(spec=[]) x y =
-  let open Plplot in
   let x = Owl_dense_matrix.D.to_array x in
   let y = Owl_dense_matrix.D.to_array y in
-  _adjust_range h x X;
-  _adjust_range h y Y;
-  (* prepare the closure *)
-  let p = h.pages.(h.current_page) in
-  let color = _get_rgb spec p.fgcolor in
-  let r, g, b = color in
-  let line_style = _get_line_style spec 1 in
-  let fill_pattern = _get_fill_pattern spec 0 in
-  (* drawing function *)
-  let f = (fun () ->
-    let r', g', b' = plgcol0 1 in
-    plscol0 1 r g b;
-    plcol0 1;
-    pllsty line_style;
-    plline x y;
-    plpsty fill_pattern;
-    plfill x y;
-    (* restore original settings *)
-    plscol0 1 r' g' b';
-    plcol0 1;
-    pllsty 1
-  )
-  in
-  (* add closure as a layer *)
-  p.plots <- Array.append p.plots [|f|];
-  (* add legend item to page *)
-  _add_legend_item p BOX line_style color "" color fill_pattern color;
-  if not h.holdon then output h
+  _area_fill h spec x y
 
 let _ecdf_interleave x i =
   let m = Array.length x in

--- a/src/owl/owl_plot.ml
+++ b/src/owl/owl_plot.ml
@@ -1011,8 +1011,13 @@ let bar ?(h=_default_handle) ?(spec=[]) y =
   if not h.holdon then output h
 
 
-let _area_fill h spec x y =
+let area ?(h=_default_handle) ?(spec=[]) x y=
   let open Plplot in
+  let x = Owl_dense_matrix.D.to_array x in
+  let y = Owl_dense_matrix.D.to_array y in
+  let xmin, xmax = Owl_stats.minmax x in
+  let x = Array.(append (append [|xmin|] x) [|xmax|]) in
+  let y = Array.(append (append [|0.|] y) [|0.|]) in
   _adjust_range h x X;
   _adjust_range h y Y;
   (* prepare the closure *)
@@ -1043,19 +1048,38 @@ let _area_fill h spec x y =
   if not h.holdon then output h
 
 
-let area ?(h=_default_handle) ?(spec=[]) x y =
-  let x = Owl_dense_matrix.D.to_array x in
-  let y = Owl_dense_matrix.D.to_array y in
-  let xmin, xmax = Owl_stats.minmax x in
-  let x = Array.(append (append [|xmin|] x) [|xmax|]) in
-  let y = Array.(append (append [|0.|] y) [|0.|]) in
-  _area_fill h spec x y
-
-
 let draw_polygon ?(h=_default_handle) ?(spec=[]) x y =
+  let open Plplot in
   let x = Owl_dense_matrix.D.to_array x in
   let y = Owl_dense_matrix.D.to_array y in
-  _area_fill h spec x y
+  _adjust_range h x X;
+  _adjust_range h y Y;
+  (* prepare the closure *)
+  let p = h.pages.(h.current_page) in
+  let color = _get_rgb spec p.fgcolor in
+  let r, g, b = color in
+  let line_style = _get_line_style spec 1 in
+  let fill_pattern = _get_fill_pattern spec 0 in
+  (* drawing function *)
+  let f = (fun () ->
+    let r', g', b' = plgcol0 1 in
+    plscol0 1 r g b;
+    plcol0 1;
+    pllsty line_style;
+    plline x y;
+    plpsty fill_pattern;
+    plfill x y;
+    (* restore original settings *)
+    plscol0 1 r' g' b';
+    plcol0 1;
+    pllsty 1
+  )
+  in
+  (* add closure as a layer *)
+  p.plots <- Array.append p.plots [|f|];
+  (* add legend item to page *)
+  _add_legend_item p BOX line_style color "" color fill_pattern color;
+  if not h.holdon then output h
 
 let _ecdf_interleave x i =
   let m = Array.length x in

--- a/src/owl/owl_plot.ml
+++ b/src/owl/owl_plot.ml
@@ -1048,6 +1048,39 @@ let area ?(h=_default_handle) ?(spec=[]) x y=
   if not h.holdon then output h
 
 
+let draw_polygon ?(h=_default_handle) ?(spec=[]) x y =
+  let open Plplot in
+  let x = Owl_dense_matrix.D.to_array x in
+  let y = Owl_dense_matrix.D.to_array y in
+  _adjust_range h x X;
+  _adjust_range h y Y;
+  (* prepare the closure *)
+  let p = h.pages.(h.current_page) in
+  let color = _get_rgb spec p.fgcolor in
+  let r, g, b = color in
+  let line_style = _get_line_style spec 1 in
+  let fill_pattern = _get_fill_pattern spec 0 in
+  (* drawing function *)
+  let f = (fun () ->
+    let r', g', b' = plgcol0 1 in
+    plscol0 1 r g b;
+    plcol0 1;
+    pllsty line_style;
+    plline x y;
+    plpsty fill_pattern;
+    plfill x y;
+    (* restore original settings *)
+    plscol0 1 r' g' b';
+    plcol0 1;
+    pllsty 1
+  )
+  in
+  (* add closure as a layer *)
+  p.plots <- Array.append p.plots [|f|];
+  (* add legend item to page *)
+  _add_legend_item p BOX line_style color "" color fill_pattern color;
+  if not h.holdon then output h
+
 let _ecdf_interleave x i =
   let m = Array.length x in
   let n = 2 * m in

--- a/src/owl/owl_plot.mli
+++ b/src/owl/owl_plot.mli
@@ -176,6 +176,14 @@ val area : ?h:handle -> ?spec:spec list -> dsmat -> dsmat -> unit
   Parameters: [RGB], [LineStyle], [FillPattern].
  *)
 
+val draw_polygon : ?h:handle -> ?spec:spec list -> dsmat -> dsmat -> unit
+(** [area x y] fills the polygon specified by [x] and [y].  Each point
+  will be treated as connected to the next point except the last, which 
+  will be connected to the first point.
+
+  Parameters: [RGB], [LineStyle], [FillPattern].
+ *)
+
 val error_bar : ?h:handle -> ?spec:spec list -> dsmat -> dsmat -> dsmat -> unit
 (** [error_bar x y] generates a line plot of [x] and [y] with error bars.
 


### PR DESCRIPTION
plot, loglog: added parentheses around let in 'if marker'

In the closure definition in `plot`, because the `let` in scope of `if marker ...` wasn't wrapped in parentheses, the `let` extended to the rest of the closure, and nothing else got executed if the `if` test failed. It's also clear from the indentation that this isn't what was intended.  Plot settings weren't getting rrestored to their previous values at the end of the closure, which caused some of the settings to carry over to the next closure when it was executed.

This fixes issue #113.  I don't know why the PR includes some old commits from my previous PR.  Let me know if I need to redo this one.

It seems clear that the same problem exists in loglog, so I fixed that. (EDIT: At first I couldn't run `loglog` just to test that I hadn't broken something, but now I figured out how to do that.)

(I haven't noticed other functions in owl_plot.ml that have this problem.  I searched through all 'if' expressions that use 'marker'.  Difficult to search for an if followed by a let on the next line.)

(This is the `loglog` error:
```ocaml
# let xs = M.sequential 1 10;;
val xs : M.mat =
   C0 C1 C2 C3 C4 C5 C6 C7 C8 C9
R0  0  1  2  3  4  5  6  7  8  9

# let h = Owl.Plot.create "foo.pdf" in Owl.Plot.(loglog ~h xs ; output h);;
Exception: Gsl__Error.Gsl_exn (Gsl__Error.EDOM, "domain error").
Raised by primitive operation at unknown location
Called from file "src/owl/owl_maths.ml", line 89, characters 14-21
Called from file "array.ml", line 91, characters 21-40
Called from file "src/owl/owl_plot.ml", line 1236, characters 41-68
Called from file "//toplevel//", line 1, characters 47-59
Called from file "toplevel/toploop.ml", line 180, characters 17-56
```
I'll try to figure out whether I'm doing something wrong and file an issue if need be.)