### PR TITLE
Fix build with OCaml 4.06.0 (and -safe-string)

### DIFF
--- a/bin/jbuild
+++ b/bin/jbuild
@@ -8,6 +8,7 @@
     owl
     owl_zoo
   ))
+  (flags (:standard -safe-string))
   (link_flags (-linkall))
   (modes      (byte))
 ))

--- a/src/ocaml/jbuild
+++ b/src/ocaml/jbuild
@@ -4,7 +4,7 @@
   (name owl_ocaml)
   (public_name owl_ocaml)
   (wrapped false)
-  (flags (:standard))
+  (flags (:standard -safe-string))
   (libraries (
 
   ))

--- a/src/owl/jbuild
+++ b/src/owl/jbuild
@@ -25,7 +25,7 @@
     -lopenblas
     -lgfortran
   ))
-  (flags (:standard))
+  (flags (:standard -safe-string))
   (libraries (
     ctypes
     ctypes.stubs

--- a/src/owl/owl_dense_common.ml
+++ b/src/owl/owl_dense_common.ml
@@ -69,7 +69,7 @@ let _neg_inf : type a b. (a, b) kind -> a = function
   | Complex64 -> Complex.({re = neg_infinity; im = neg_infinity})
   | _         -> failwith "_neg_inf: unsupported operation"
 
-let _owl_elt_to_str : type a b. (a, b) kind -> (a -> bytes) = function
+let _owl_elt_to_str : type a b. (a, b) kind -> (a -> string) = function
   | Char           -> fun v -> Printf.sprintf "%c" v
   | Nativeint      -> fun v -> Printf.sprintf "%nd" v
   | Int8_signed    -> fun v -> Printf.sprintf "%i" v

--- a/src/owl/owl_nlp_corpus.ml
+++ b/src/owl/owl_nlp_corpus.ml
@@ -234,7 +234,7 @@ let unique fi_name fo_name =
     match Hashtbl.mem h s with
     | true  -> Owl_utils.Stack.push rm i
     | false -> (
-        output_bytes fo s;
+        output_string fo s;
         output_char fo '\n';
         Hashtbl.add h s None;
       )
@@ -300,7 +300,7 @@ let save_txt corpus f =
       |> Array.to_list
       |> String.concat " "
     in
-    output_bytes fh s;
+    output_string fh s;
     output_char fh '\n';
   ) corpus;
   close_out fh

--- a/src/owl/owl_nlp_vocabulary.ml
+++ b/src/owl/owl_nlp_vocabulary.ml
@@ -201,7 +201,7 @@ let save_txt d fname =
   List.fast_sort (fun x y -> String.compare (fst x) (fst y)) vl
   |> List.iter (fun (w,i) ->
     let s = Printf.sprintf "%s %i\n" w i in
-    output_bytes fh s
+    output_string fh s
   );
   close_out fh
 

--- a/src/owl/owl_pretty.mli
+++ b/src/owl/owl_pretty.mli
@@ -8,7 +8,7 @@
 val pp_dsnda : Format.formatter -> ('a, 'b, 'c) Bigarray.Genarray.t -> unit
 (** [pp_dsnda] is the pretty printer for n-dimensional arrays. *)
 
-val print : ?header:bool -> ?max_row:int -> ?max_col:int -> ?elt_to_str_fun:('a -> bytes) ->
+val print : ?header:bool -> ?max_row:int -> ?max_col:int -> ?elt_to_str_fun:('a -> string) ->
   ?formatter:Format.formatter -> ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t -> unit
 (** [print] provides the better control of pretty printing function of owl's
  n-dimensional array. [max_row] and [max_col] specify the maximum number of rows

--- a/src/top/jbuild
+++ b/src/top/jbuild
@@ -5,7 +5,7 @@
   (public_name owl_top)
   (wrapped false)
   (modes (byte))
-  (flags (:standard))
+  (flags (:standard -safe-string))
   (libraries (
     owl
     owl_zoo

--- a/src/zoo/jbuild
+++ b/src/zoo/jbuild
@@ -5,7 +5,7 @@
   (public_name owl_zoo)
   (wrapped false)
   (modes (byte))
-  (flags (:standard))
+  (flags (:standard -safe-string))
   (libraries (
     owl
     ocaml-compiler-libs.toplevel

--- a/test/jbuild
+++ b/test/jbuild
@@ -6,6 +6,7 @@
     owl
     alcotest
   ))
+  (flags (:standard -safe-string))
 ))
 
 (alias (


### PR DESCRIPTION
OCaml 4.06.0 uses `-safe-string` by default and so we have to distinguish between immutable `string` and mutable `bytes`.

This PR fixes the build for 4.06.0 and switches on `-safe-string` for all OCaml versions.