### PR TITLE
Add Kolmogorov-Smirnov Tests to the Stats Module

### DIFF
--- a/src/owl/owl_stats.ml
+++ b/src/owl/owl_stats.ml
@@ -718,7 +718,6 @@ let smirnov n e =
     let sum' = sum +. c *. (evn ** (float_of_int (v - 1)))
                          *. ((1. -. evn) ** (float_of_int (n - v))) in
     let c' = c *. (float_of_int (n - v)) /. (float_of_int (v + 1)) in
-    Printf.printf "helper evn=%f sum'=%f c'=%f v=%d nn=%d\n" evn sum' c' v nn;
     if v <= nn then
       helper sum' (v + 1) c'
     else
@@ -752,77 +751,6 @@ let smirnov n e =
   else
     e *. (helper2 ())
 
-(*
-double smirnov(int n, double e)
-{
-    int v, nn;
-    double evn, omevn, p, t, c, lgamnp1;
-
-    /* This comparison should assure returning NaN whenever
-     * e is NaN itself.  In original || form it would proceed */
-    if (!(n > 0 && e >= 0.0 && e <= 1.0))
-	return (NPY_NAN);
-    if (e == 0.0)
-	return 1.0;
-    nn = (int) (floor((double) n * (1.0 - e)));
-    p = 0.0;
-    if (n < 1013) {
-	c = 1.0;
-	for (v = 0; v <= nn; v++) {
-	    evn = e + ((double) v) / n;
-	    p += c * pow(evn, (double) (v - 1))
-		* pow(1.0 - evn, (double) (n - v));
-	    /* Next combinatorial term; worst case error = 4e-15.  */
-	    c *= ((double) (n - v)) / (v + 1);
-	}
-    }
-    else {
-	lgamnp1 = lgam((double) (n + 1));
-	for (v = 0; v <= nn; v++) {
-	    evn = e + ((double) v) / n;
-	    omevn = 1.0 - evn;
-	    if (fabs(omevn) > 0.0) {
-		t = lgamnp1 - lgam((double) (v + 1))
-		    - lgam((double) (n - v + 1))
-		    + (v - 1) * log(evn)
-		    + (n - v) * log(omevn);
-		if (t > -MAXLOG)
-		    p += exp(t);
-	    }
-	}
-    }
-    return (p * e);
-}
-
-/* Kolmogorov's limiting distribution of two-sided test, returns
- * probability that sqrt(n) * max deviation > y,
- * or that max deviation > y/sqrt(n).
- * The approximation is useful for the tail of the distribution
- * when n is large.  */
-double kolmogorov(double y)
-{
-    double p, t, r, sign, x;
-
-    if (y < 1.1e-16)
-	return 1.0;
-    x = -2.0 * y * y;
-    sign = 1.0;
-    p = 0.0;
-    r = 1.0;
-    do {
-	t = exp(x * r * r);
-	p += sign * t;
-	if (t == 0.0)
-	    break;
-	r += 1.0;
-	sign = -sign;
-    }
-    while ((t / p) > 1.1e-16);
-    return (p + p);
-}
-
-*)
-
 let kolmogorov y =
   let x = (-2.) *. y *. y in
   let rec helper sign sum r =
@@ -837,13 +765,6 @@ let kolmogorov y =
   else
     2. *. helper 1. 0. 1.
 
-(*let sort x =
-  let cmp u v = if u = v then 0 else if u < v then 1 else -1 in
-  let x' = Array.copy x in
-  Array.sort cmp  x';
-  x'
- *)
-
 let ks_test ?(alpha=0.05) x f =
   let x' = sort x in
   let max p q = if p > q then p else q in
@@ -857,7 +778,6 @@ let ks_test ?(alpha=0.05) x f =
   let d = max d1 d2 in
   let pval =  2. *. (smirnov n d) in
   let pval2 = kolmogorov (d *. sqrt nn) in
-  Printf.printf "Final: n=%n d=%f pval=%f pval2=%f\n" n d pval pval2;
   if n = 0 then raise EXN_EMPTY_ARRAY
   else if n > 2666 || pval2 > 0.8 -. nn *. 0.003
   then (pval2 < alpha, pval2, d)
@@ -870,26 +790,29 @@ let rec uniques l = match l with
      if x1 = x2 then uniques (x2 :: xs)
      else x1 :: (uniques (x2 :: xs))
 
-let rec count x samples = match samples with
-  | [] -> (0, samples)
-  | y :: ys ->
-     if x = y then
-       let (n, rest) = count x ys in
-       (n + 1, rest)
-     else
-       (0, samples)
-
-let rec hist accum domain samples = match domain with
-  | [] -> []
-  | x :: xs ->
-     let (p, rest) = count x samples in
-     let accum' = accum + p in
-     accum' :: (hist accum' xs rest)
-
+(* Compute the empirical CDF of a list of samples from the input
+   domain (sorted list of floats). The output is a list of length
+   equal to domain. Both inputs are assumed to be sorted. *)
 let empCdf domain samples =
+  let rec count x samples = match samples with
+    | [] -> (0, samples)
+    | y :: ys ->
+       if x = y then
+         let (n, rest) = count x ys in
+         (n + 1, rest)
+       else
+         (0, samples)
+  in
+  let rec aggregate accum domain samples = match domain with
+    | [] -> []
+    | x :: xs ->
+       let (p, rest) = count x samples in
+       let accum' = accum + p in
+       accum' :: (aggregate accum' xs rest)
+  in
   let n = float_of_int (List.length samples) in
-  let h = hist 0 domain samples in
-  List.map (fun x -> (float_of_int x) /. n) h
+  let a = aggregate 0 domain samples in
+  List.map (fun x -> (float_of_int x) /. n) a
 
 let ks2_test ?(alpha=0.05) x y =
   let n1 = Array.length x in
@@ -909,7 +832,6 @@ let ks2_test ?(alpha=0.05) x y =
     let d = List.fold_left max 0. diffs in
     let en = sqrt (nn1 *. nn2 /. (nn1 +. nn2)) in
     let pval = kolmogorov ((en +. 0.12 +. 0.11 /. en) *. d) in
-    Printf.printf "Final: n1=%n n2=%n pval=%f d=%f" n1 n2 pval d;
     (pval < alpha, pval, d)
 
 let ad_test x = None

--- a/src/owl/owl_stats.ml
+++ b/src/owl/owl_stats.ml
@@ -712,6 +712,8 @@ let t_test_unpaired ?(alpha=0.05) ?(side=BothSide) ?(equal_var=true) x y =
 let ks_test x = None
 (* One-sample Kolmogorov-Smirnov test *)
 
+exception EXN_EMPTY_ARRAY
+
 let ks2_test ?(alpha=0.05) x y =
   (true, 0.0, 0.0)
 

--- a/src/owl/owl_stats.ml
+++ b/src/owl/owl_stats.ml
@@ -712,8 +712,8 @@ let t_test_unpaired ?(alpha=0.05) ?(side=BothSide) ?(equal_var=true) x y =
 let ks_test x = None
 (* One-sample Kolmogorov-Smirnov test *)
 
-let ks2_test x = None
-(* Two-sample Kolmogorov-Smirnov test *)
+let ks2_test ?(alpha=0.05) x y =
+  (true, 0.0, 0.0)
 
 let ad_test x = None
 (* Anderson-Darling test *)

--- a/src/owl/owl_stats.ml
+++ b/src/owl/owl_stats.ml
@@ -784,8 +784,8 @@ let ks_test ?(alpha=0.05) x f =
   else (pval < alpha, pval, d)
 
 let rec uniques l = match l with
-  | [] -> []
-  | x :: [] -> x :: []
+  | []             -> []
+  | x :: []        -> x :: []
   | x1 :: x2 :: xs ->
      if x1 = x2 then uniques (x2 :: xs)
      else x1 :: (uniques (x2 :: xs))
@@ -795,7 +795,7 @@ let rec uniques l = match l with
    equal to domain. Both inputs are assumed to be sorted. *)
 let empCdf domain samples =
   let rec count x samples = match samples with
-    | [] -> (0, samples)
+    | []      -> (0, samples)
     | y :: ys ->
        if x = y then
          let (n, rest) = count x ys in
@@ -804,7 +804,7 @@ let empCdf domain samples =
          (0, samples)
   in
   let rec aggregate accum domain samples = match domain with
-    | [] -> []
+    | []      -> []
     | x :: xs ->
        let (p, rest) = count x samples in
        let accum' = accum + p in

--- a/src/owl/owl_stats.mli
+++ b/src/owl/owl_stats.mli
@@ -189,6 +189,8 @@ val t_test_unpaired : ?alpha:float -> ?side:tail -> ?equal_var:bool -> float arr
   two variances are not the same, the test is referred to as Welche's t-test.
  *)
 
+exception EXN_EMPTY_ARRAY
+
 val ks2_test : ?alpha:float -> float array -> float array -> bool * float * float
 
 (** [ks2_test ~alpha x y] returns a test decision for the null

--- a/src/owl/owl_stats.mli
+++ b/src/owl/owl_stats.mli
@@ -191,6 +191,20 @@ val t_test_unpaired : ?alpha:float -> ?side:tail -> ?equal_var:bool -> float arr
 
 exception EXN_EMPTY_ARRAY
 
+val ks_test : ?alpha:float -> float array -> (float -> float) -> bool * float * float
+
+(** [ks_test ~alpha x f] returns a test decision for the null
+   hypothesis that the data in vector [x] comes from independent
+   random samples of the distribution with CDF f. The alternative
+   hypothesis is that the data in [x] comes from a different
+   distribution.
+
+    The result [h,p,d]: [h] is [true] if the test rejects the null
+   hypothesis at the [alpha] significance level, and [false]
+   otherwise. [p] is the p-value and [d] is the Kolmogorov-Smirnov
+   test statistic. *)
+
+
 val ks2_test : ?alpha:float -> float array -> float array -> bool * float * float
 
 (** [ks2_test ~alpha x y] returns a test decision for the null

--- a/src/owl/owl_stats.mli
+++ b/src/owl/owl_stats.mli
@@ -189,6 +189,20 @@ val t_test_unpaired : ?alpha:float -> ?side:tail -> ?equal_var:bool -> float arr
   two variances are not the same, the test is referred to as Welche's t-test.
  *)
 
+val ks2_test : ?alpha:float -> float array -> float array -> bool * float * float
+
+(** [ks2_test ~alpha x y] returns a test decision for the null
+    hypothesis that the data in vectors [x] and [y] come from
+    independent random samples of the same distribution. The
+    alternative hypothesis is that the data in [x] and [y] are sampled
+    from different distributions.
+
+    The result [h,p,d]: [h] is [true] if the test rejects the null
+    hypothesis at the [alpha] significance level, and [false]
+    otherwise. [p] is the p-value and [d] is the Kolmogorov-Smirnov
+    test statistic.
+*)
+
 val var_test : ?alpha:float -> ?side:tail -> var:float -> float array -> bool * float * float
 (** [var_test ~alpha ~side ~var x] returns a test decision for the null
   hypothesis that the data in [x] comes from a normal distribution with

--- a/test/unit_stats.ml
+++ b/test/unit_stats.ml
@@ -34,6 +34,12 @@ module To_test = struct
   let fisher_test_left_side a b c d =
     let (_, p, _) = M.fisher_test ~side:M.LeftSide a b c d in
     p
+  let ks2_test_pval a b =
+    let (_, p, _) = M.ks2_test a b in
+    p
+  let ks2_test_statistic a b =
+    let (_, _, s) = M.ks2_test a b in
+    s
 end
 
 (* The tests *)
@@ -134,8 +140,36 @@ let wilcoxon_test_left_side_asymp () =
     true
      (abs_float((To_test.wilcoxon_left_side [|10.;9.;8.;7.;6.|] [|10.; 3.; 1.; 3.; 2.|]) -. 0.0328) < 0.001)
 
+let ks2_teststat () =
+  Alcotest.(check bool)
+    "ks2_test test statistic"
+    true
+    (abs_float((To_test.ks2_test_statistic
+                  [| 0.; 2.; 3.; 1.; 4.|]
+                  [| 6.; 5.; 3.; 4.;|]) -. 0.6) < 0.0001)
 
+let ks2_pval_test1 () =
+  Alcotest.(check bool)
+    "ks2_test p value"
+    true
+    (abs_float((To_test.ks2_test_pval
+                  [| 0.; 2.; 3.; 1.; 4.|]
+                  [| 6.; 5.; 3.; 4.;|]) -. 0.2587) < 0.0001)
 
+let ks2_pval_test2 () =
+  Alcotest.(check bool)
+    "ks2_test p value"
+    true
+    (abs_float((To_test.ks2_test_pval
+                  [|8.3653642; 9.39604144; 9.567219; 8.95912556; 9.97116074|]
+                  [|1.7835817; -0.37877421; -1.21761325;  0.91270459; -1.06491371|])
+               -. 0.003781) < 0.0001)
+
+let ks2_pval_test3 () =
+  Alcotest.check_raises
+    "ks2_test exception"
+    M.EXN_EMPTY_ARRAY
+    (fun _ -> ignore (To_test.ks2_test_pval [||] [|1.; 2.; 3.;|]);)
 
 (* The tests *)
 let test_set = [
@@ -152,6 +186,10 @@ let test_set = [
   "wilcoxon_test_right_side_asymp" , `Slow, wilcoxon_test_right_side_asymp;
   "wilcoxon_test_left_side_asymp" , `Slow, wilcoxon_test_left_side_asymp;
   "fisher_test_both_side" , `Slow, fisher_test_both_side;
-  "fisher_test_right_side", `Slow , fisher_test_right_side ;
+  "fisher_test_right_side", `Slow , fisher_test_right_side;
   "fisher_test_left_side", `Slow, fisher_test_left_side;
-  ]
+  "ks2_pval_test1", `Slow, ks2_pval_test1;
+  "ks2_pval_test2", `Slow, ks2_pval_test2;
+  "ks2_pval_test3", `Slow, ks2_pval_test3;
+  "ks2_teststat", `Slow, ks2_teststat;
+]

--- a/test/unit_stats.ml
+++ b/test/unit_stats.ml
@@ -178,11 +178,6 @@ let ks_pval_test2 () =
                   [| 0.; 0.25; 0.15; 0.05 |]
                   (fun x -> M.Cdf.gaussian_P x 1.0)) -. 0.1875) < 0.0001)
 
-(*
-stats.kstest([0.99 * 0.0001 * k for k in range(0,10000)], stats.uniform.cdf)
-Out[72]: KstestResult(statistic=0.010098999999999969, pvalue=0.25953830350891244)
- *)
-
 let ks_pval_test3 () =
   Alcotest.(check bool)
   "ks_test pval 3"

--- a/test/unit_stats.ml
+++ b/test/unit_stats.ml
@@ -34,6 +34,12 @@ module To_test = struct
   let fisher_test_left_side a b c d =
     let (_, p, _) = M.fisher_test ~side:M.LeftSide a b c d in
     p
+  let ks_test_pval a b =
+    let (_, p, _) = M.ks_test a b in
+    p
+  let ks_test_statistic a b =
+    let (_, _, s) = M.ks_test a b in
+    s
   let ks2_test_pval a b =
     let (_, p, _) = M.ks2_test a b in
     p
@@ -140,6 +146,66 @@ let wilcoxon_test_left_side_asymp () =
     true
      (abs_float((To_test.wilcoxon_left_side [|10.;9.;8.;7.;6.|] [|10.; 3.; 1.; 3.; 2.|]) -. 0.0328) < 0.001)
 
+let ks_teststat1 () =
+  Alcotest.(check bool)
+    "ks_test test stat"
+    true
+    (abs_float((To_test.ks_test_statistic
+                  [| 1.; 2.; 3. |]
+                  (fun x -> M.Cdf.gaussian_P x 1.0)) -. 0.8413) < 0.0001)
+
+let ks_teststat2 () =
+  Alcotest.(check bool)
+    "ks_test pval 4"
+    true
+    (abs_float((To_test.ks_test_statistic
+                  [| 0.; 0.; 0. |]
+                  (fun x -> M.Cdf.gaussian_P x 1.0)) -. 0.5) < 0.0001)
+
+let ks_pval_test1 () =
+  Alcotest.(check bool)
+    "ks_test pval 1"
+    true
+    (abs_float((To_test.ks_test_pval
+                  [| 1.; 2.; 3. |]
+                  (fun x -> M.Cdf.gaussian_P x 1.0)) -. 0.0079) < 0.0001)
+
+let ks_pval_test2 () =
+  Alcotest.(check bool)
+    "ks_test pval 2"
+    true
+    (abs_float((To_test.ks_test_pval
+                  [| 0.; 0.25; 0.15; 0.05 |]
+                  (fun x -> M.Cdf.gaussian_P x 1.0)) -. 0.1875) < 0.0001)
+
+(*
+stats.kstest([0.99 * 0.0001 * k for k in range(0,10000)], stats.uniform.cdf)
+Out[72]: KstestResult(statistic=0.010098999999999969, pvalue=0.25953830350891244)
+ *)
+
+let ks_pval_test3 () =
+  Alcotest.(check bool)
+  "ks_test pval 3"
+    true
+    (abs_float((To_test.ks_test_pval
+                  (Array.mapi (fun i _ -> 0.99 /. 2000. *. float_of_int i) (Array.create_float 2000))
+                  (fun x -> M.Cdf.flat_P x 0. 1.)) -. 0.98025) < 0.00001)
+
+let ks_pval_test4 () =
+  Alcotest.(check bool)
+  "ks_test pval 4"
+    true
+    (abs_float((To_test.ks_test_pval
+                  (Array.mapi (fun i _ -> 0.99 /. 10_000. *. float_of_int i) (Array.create_float 10_000))
+                  (fun x -> M.Cdf.flat_P x 0. 1.)) -. 0.25953) < 0.00001)
+
+let ks_pval_test5 () =
+  Alcotest.check_raises
+    "ks_test exception"
+    M.EXN_EMPTY_ARRAY
+    (fun _ -> ignore (To_test.ks_test_pval [| |] (fun x -> M.Cdf.gaussian_P x 1.0));)
+
+
 let ks2_teststat () =
   Alcotest.(check bool)
     "ks2_test test statistic"
@@ -188,6 +254,13 @@ let test_set = [
   "fisher_test_both_side" , `Slow, fisher_test_both_side;
   "fisher_test_right_side", `Slow , fisher_test_right_side;
   "fisher_test_left_side", `Slow, fisher_test_left_side;
+  "ks_teststat1", `Slow, ks_teststat1;
+  "ks_teststat2", `Slow, ks_teststat2;
+  "ks_pval_test1", `Slow, ks_pval_test1;
+  "ks_pval_test2", `Slow, ks_pval_test2;
+  "ks_pval_test3", `Slow, ks_pval_test3;
+  "ks_pval_test4", `Slow, ks_pval_test4;
+  "ks_pval_test5", `Slow, ks_pval_test5;
   "ks2_pval_test1", `Slow, ks2_pval_test1;
   "ks2_pval_test2", `Slow, ks2_pval_test2;
   "ks2_pval_test3", `Slow, ks2_pval_test3;


### PR DESCRIPTION
This change adds one and two sample Kolmogorov-Smirnov tests to `Owl.Stats`. To create my tests, I relied on a comparison with SciPy (along with reading papers/books). As a fair warning, I'm still pretty new to OCaml and Owl; apologies in advance if there are some style/mechanics issues in this PR. 
 