### PR TITLE
Added lib path for macOS to find openblas

### DIFF
--- a/src/owl/jbuild
+++ b/src/owl/jbuild
@@ -22,6 +22,7 @@
   ))
   (c_library_flags (
     -L/usr/local/lib/gcc/7
+    -L/usr/local/opt/openblas/lib
     -lopenblas
     -lgfortran
     -lm


### PR DESCRIPTION
Added lib path for macOS to find `openblas`.

This shouldn't affect other OS that already find `openblas`. macOS doesn't have `libopenblas.[a|dylib]` in `/usr/local/lib` or `/usr/lib`.