### PR TITLE
add mpow function: iterate dot prod of matrix with itself

### DIFF
--- a/src/owl/jbuild
+++ b/src/owl/jbuild
@@ -22,6 +22,7 @@
   ))
   (c_library_flags (
     -L/usr/local/lib/gcc/7
+    -L/usr/local/opt/openblas/lib
     -lopenblas
     -lgfortran
     -lm

--- a/src/owl/jbuild
+++ b/src/owl/jbuild
@@ -22,6 +22,7 @@
   ))
   (c_library_flags (
     -L/usr/local/lib/gcc/7
+    -L/usr/local/opt/openblas/lib 
     -lopenblas
     -lgfortran
     -lm

--- a/src/owl/jbuild
+++ b/src/owl/jbuild
@@ -22,7 +22,6 @@
   ))
   (c_library_flags (
     -L/usr/local/lib/gcc/7
-    -L/usr/local/opt/openblas/lib
     -lopenblas
     -lgfortran
     -lm

--- a/src/owl/owl_dense_matrix_c.mli
+++ b/src/owl/owl_dense_matrix_c.mli
@@ -589,6 +589,8 @@ val scalar_pow : elt -> mat -> mat
 
 val pow_scalar : mat -> elt -> mat
 
+val mpow : mat -> float -> mat
+
 val cov : ?b:mat -> a:mat -> mat
 
 val kron : mat -> mat -> mat

--- a/src/owl/owl_dense_matrix_d.mli
+++ b/src/owl/owl_dense_matrix_d.mli
@@ -592,6 +592,8 @@ val scalar_pow : elt -> mat -> mat
 
 val pow_scalar : mat -> elt -> mat
 
+val mpow : mat -> float -> mat
+
 val atan2 : mat -> mat -> mat
 
 val scalar_atan2 : elt -> mat -> mat

--- a/src/owl/owl_dense_matrix_generic.mli
+++ b/src/owl/owl_dense_matrix_generic.mli
@@ -1401,7 +1401,8 @@ val pow_scalar : ('a, 'b) t -> 'a -> ('a, 'b) t
 (** [pow_scalar x a] *)
 
 val mpow : ('a, 'b) t -> float -> ('a, 'b) t
-(** [mpow x r] returns the dot product of [x] with itself [r] times. *)
+(** [mpow x r] returns the dot product of square matrix [x] with 
+  itself [r] times. *)
 
 val atan2 : (float, 'a) t -> (float, 'a) t -> (float, 'a) t
 (** [atan2 x y] computes [atan2(a, b)] of all the elements in [x] and [y]

--- a/src/owl/owl_dense_matrix_generic.mli
+++ b/src/owl/owl_dense_matrix_generic.mli
@@ -1402,7 +1402,10 @@ val pow_scalar : ('a, 'b) t -> 'a -> ('a, 'b) t
 
 val mpow : ('a, 'b) t -> float -> ('a, 'b) t
 (** [mpow x r] returns the dot product of square matrix [x] with 
-  itself [r] times. *)
+  itself [r] times, and more generally raises the matrix to the
+  [r]th power.  [r] is a float that must be equal to an integer;
+  it can be be negative, zero, or positive. Non-integer exponents
+  are not yet implemented. *)
 
 val atan2 : (float, 'a) t -> (float, 'a) t -> (float, 'a) t
 (** [atan2 x y] computes [atan2(a, b)] of all the elements in [x] and [y]

--- a/src/owl/owl_dense_matrix_generic.mli
+++ b/src/owl/owl_dense_matrix_generic.mli
@@ -1400,6 +1400,9 @@ val scalar_pow : 'a -> ('a, 'b) t -> ('a, 'b) t
 val pow_scalar : ('a, 'b) t -> 'a -> ('a, 'b) t
 (** [pow_scalar x a] *)
 
+val mpow : ('a, 'b) t -> float -> ('a, 'b) t
+(** [mpow x r] returns the dot product of [x] with itself [r] times. *)
+
 val atan2 : (float, 'a) t -> (float, 'a) t -> (float, 'a) t
 (** [atan2 x y] computes [atan2(a, b)] of all the elements in [x] and [y]
   elementwise, and returns the result in a new matrix.

--- a/src/owl/owl_dense_matrix_s.mli
+++ b/src/owl/owl_dense_matrix_s.mli
@@ -592,6 +592,8 @@ val scalar_pow : elt -> mat -> mat
 
 val pow_scalar : mat -> elt -> mat
 
+val mpow : mat -> float -> mat
+
 val atan2 : mat -> mat -> mat
 
 val scalar_atan2 : elt -> mat -> mat

--- a/src/owl/owl_dense_matrix_z.mli
+++ b/src/owl/owl_dense_matrix_z.mli
@@ -589,6 +589,8 @@ val scalar_pow : elt -> mat -> mat
 
 val pow_scalar : mat -> elt -> mat
 
+val mpow : mat -> float -> mat
+
 val cov : ?b:mat -> a:mat -> mat
 
 val kron : mat -> mat -> mat

--- a/src/owl/owl_dense_ndarray_generic.ml
+++ b/src/owl/owl_dense_ndarray_generic.ml
@@ -3326,7 +3326,7 @@ let dot x1 x2 =
   x3
 
 let mpow x r =
-  let (frac_part, whole_part) = Pervasives.modf r in
+  let (frac_part, _) = Pervasives.modf r in
   if frac_part <> 0. then failwith "mpow: fractional powers not implemented";
   let m, n = _matrix_shape x in assert (m = n);
   (* integer matrix powers using floats: *)

--- a/src/owl/owl_dense_ndarray_generic.ml
+++ b/src/owl/owl_dense_ndarray_generic.ml
@@ -3306,7 +3306,6 @@ let copy_col_to v x i =
   let r2 = area_of_col x i in
   copy_area_to v r1 x r2
 
-
 let dot x1 x2 =
   let m, k = _matrix_shape x1 in
   let l, n = _matrix_shape x2 in
@@ -3326,6 +3325,23 @@ let dot x1 x2 =
   Owl_cblas.gemm layout transa transb m n k alpha a k b n beta c n;
   x3
 
+let mpow x r =
+  let (frac_part, whole_part) = Pervasives.modf r in
+  if frac_part <> 0. then failwith "mpow: fractional powers not implemented";
+  let m, n = _matrix_shape x in assert (m = n);
+  (* integer matrix powers using floats: *)
+  if r < 1. then failwith "mpow: exponent is non-positive";
+  let rec either_pow s acc =
+     if s = 1. then acc
+     else if mod_float s 2. = 0.
+     then even_pow s acc
+     else odd_pow s acc
+  and even_pow s acc =
+    let acc2 = either_pow (s /. 2.) acc in
+    dot acc2 acc2
+  and odd_pow s acc =
+    dot x (even_pow (s -. 1.) acc)
+  in either_pow r x
 
 let inv x =
   let m, n = _matrix_shape x in

--- a/src/owl/owl_dense_ndarray_generic.ml
+++ b/src/owl/owl_dense_ndarray_generic.ml
@@ -3331,17 +3331,15 @@ let mpow x r =
   let m, n = _matrix_shape x in assert (m = n);
   (* integer matrix powers using floats: *)
   if r < 1. then failwith "mpow: exponent is non-positive";
-  let rec either_pow s acc =
+  let rec _mpow s acc =
      if s = 1. then acc
-     else if mod_float s 2. = 0.
-     then even_pow s acc
-     else odd_pow s acc
-  and even_pow s acc =
-    let acc2 = either_pow (s /. 2.) acc in
+     else if mod_float s 2. = 0.  (* exponent is even? *)
+     then even_mpow s acc
+     else dot x (even_mpow (s -. 1.) acc)
+  and even_mpow s acc =
+    let acc2 = _mpow (s /. 2.) acc in
     dot acc2 acc2
-  and odd_pow s acc =
-    dot x (even_pow (s -. 1.) acc)
-  in either_pow r x
+  in _mpow r x
 
 let inv x =
   let m, n = _matrix_shape x in

--- a/src/owl/owl_dense_ndarray_generic.ml
+++ b/src/owl/owl_dense_ndarray_generic.ml
@@ -3306,6 +3306,7 @@ let copy_col_to v x i =
   let r2 = area_of_col x i in
   copy_area_to v r1 x r2
 
+
 let dot x1 x2 =
   let m, k = _matrix_shape x1 in
   let l, n = _matrix_shape x2 in
@@ -3325,6 +3326,7 @@ let dot x1 x2 =
   Owl_cblas.gemm layout transa transb m n k alpha a k b n beta c n;
   x3
 
+
 let mpow x r =
   let (frac_part, _) = Pervasives.modf r in
   if frac_part <> 0. then failwith "mpow: fractional powers not implemented";
@@ -3340,6 +3342,7 @@ let mpow x r =
     let acc2 = _mpow (s /. 2.) acc in
     dot acc2 acc2
   in _mpow r x
+
 
 let inv x =
   let m, n = _matrix_shape x in

--- a/src/owl/owl_dense_ndarray_generic.mli
+++ b/src/owl/owl_dense_ndarray_generic.mli
@@ -1197,6 +1197,9 @@ val scalar_pow : 'a -> ('a, 'b) t -> ('a, 'b) t
 val pow_scalar : ('a, 'b) t -> 'a -> ('a, 'b) t
 (** [pow_scalar x a] computes each element in [x] power to [a]. *)
 
+val mpow : ('a, 'b) t -> float -> ('a, 'b) t
+(** [mpow x r] returns the dot product of [x] with itself [r] times. *)
+
 val atan2 : (float, 'a) t -> (float, 'a) t -> (float, 'a) t
 (** [atan2 x y] computes [atan2(a, b)] of all the elements in [x] and [y]
   elementwise, and returns the result in a new ndarray.

--- a/src/owl/owl_dense_ndarray_generic.mli
+++ b/src/owl/owl_dense_ndarray_generic.mli
@@ -1199,7 +1199,10 @@ val pow_scalar : ('a, 'b) t -> 'a -> ('a, 'b) t
 
 val mpow : ('a, 'b) t -> float -> ('a, 'b) t
 (** [mpow x r] returns the dot product of square matrix [x] with 
-  itself [r] times. *)
+  itself [r] times, and more generally raises the matrix to the
+  [r]th power.  [r] is a float that must be equal to an integer;
+  it can be be negative, zero, or positive. Non-integer exponents
+  are not yet implemented. *)
 
 val atan2 : (float, 'a) t -> (float, 'a) t -> (float, 'a) t
 (** [atan2 x y] computes [atan2(a, b)] of all the elements in [x] and [y]

--- a/src/owl/owl_dense_ndarray_generic.mli
+++ b/src/owl/owl_dense_ndarray_generic.mli
@@ -1198,7 +1198,8 @@ val pow_scalar : ('a, 'b) t -> 'a -> ('a, 'b) t
 (** [pow_scalar x a] computes each element in [x] power to [a]. *)
 
 val mpow : ('a, 'b) t -> float -> ('a, 'b) t
-(** [mpow x r] returns the dot product of [x] with itself [r] times. *)
+(** [mpow x r] returns the dot product of square matrix [x] with 
+  itself [r] times. *)
 
 val atan2 : (float, 'a) t -> (float, 'a) t -> (float, 'a) t
 (** [atan2 x y] computes [atan2(a, b)] of all the elements in [x] and [y]


### PR DESCRIPTION
(I took the extreme step of deleting my fork and making a new one.  Trying to clean up a git history is a pita.  This seemed easier.  I hope it causes no problems.)

This PR adds this function:
```
(** [mpow x r] returns the dot product of square matrix [x] with itself [r] times. *)
```

The exponent `r` is a `float`, but must be a nonzero natural number.  An exception is raised otherwise.

Questions:

- Should the ocamldoc mention that only whole numbers are allowed?
- Should `mpow` handle the exponent 0.0, returning an identity matrix of the correct size?
- Have I modified all and only the right files?  I followed existing patterns, adding the signature to a number of files in order follow the same patterns (and to cause `mpow` to be included `Owl.Mat`).  I wasn't sure whether what I did in files other than src/owl/owl_dense_ndarray_generic.ml*` was correct.