### PR TITLE
core: add complex support for conv fun

### DIFF
--- a/src/owl/core/owl_ndarray.ml
+++ b/src/owl/core/owl_ndarray.ml
@@ -143,6 +143,7 @@ external owl_float64_ndarray_maxpool_argmax_spatial : ('a, 'b) owl_arr -> ('a, '
 "stub_float64_ndarray_maxpool_spatial_arg_bytecode"
 "stub_float64_ndarray_maxpool_spatial_arg_native"
 
+
 (* Convolution Operations *)
 
 external owl_float32_ndarray_conv_spatial : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
@@ -192,6 +193,54 @@ external owl_float64_ndarray_conv_cuboid_backward_kernel : ('a, 'b) owl_arr -> (
 external owl_float64_ndarray_conv_cuboid_backward_input : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
 "stub_float64_ndarray_conv_cuboid_backward_input_bytecode"
 "stub_float64_ndarray_conv_cuboid_backward_input_native"
+
+external owl_complex32_ndarray_conv_spatial : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
+"stub_complex32_ndarray_conv_spatial_bytecode"
+"stub_complex32_ndarray_conv_spatial_native"
+
+external owl_complex32_ndarray_conv_spatial_backward_kernel : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
+"stub_complex32_ndarray_conv_spatial_backward_kernel_bytecode"
+"stub_complex32_ndarray_conv_spatial_backward_kernel_native"
+
+external owl_complex32_ndarray_conv_spatial_backward_input : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
+"stub_complex32_ndarray_conv_spatial_backward_input_bytecode"
+"stub_complex32_ndarray_conv_spatial_backward_input_native"
+
+external owl_complex32_ndarray_conv_cuboid : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
+"stub_complex32_ndarray_conv_cuboid_bytecode"
+"stub_complex32_ndarray_conv_cuboid_native"
+
+external owl_complex32_ndarray_conv_cuboid_backward_kernel : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
+"stub_complex32_ndarray_conv_cuboid_backward_kernel_bytecode"
+"stub_complex32_ndarray_conv_cuboid_backward_kernel_native"
+
+external owl_complex32_ndarray_conv_cuboid_backward_input : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
+"stub_complex32_ndarray_conv_cuboid_backward_input_bytecode"
+"stub_complex32_ndarray_conv_cuboid_backward_input_native"
+
+external owl_complex64_ndarray_conv_spatial : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
+"stub_complex64_ndarray_conv_spatial_bytecode"
+"stub_complex64_ndarray_conv_spatial_native"
+
+external owl_complex64_ndarray_conv_spatial_backward_kernel : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
+"stub_complex64_ndarray_conv_spatial_backward_kernel_bytecode"
+"stub_complex64_ndarray_conv_spatial_backward_kernel_native"
+
+external owl_complex64_ndarray_conv_spatial_backward_input : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
+"stub_complex64_ndarray_conv_spatial_backward_input_bytecode"
+"stub_complex64_ndarray_conv_spatial_backward_input_native"
+
+external owl_complex64_ndarray_conv_cuboid : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
+"stub_complex64_ndarray_conv_cuboid_bytecode"
+"stub_complex64_ndarray_conv_cuboid_native"
+
+external owl_complex64_ndarray_conv_cuboid_backward_kernel : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
+"stub_complex64_ndarray_conv_cuboid_backward_kernel_bytecode"
+"stub_complex64_ndarray_conv_cuboid_backward_kernel_native"
+
+external owl_complex64_ndarray_conv_cuboid_backward_input : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> unit =
+"stub_complex64_ndarray_conv_cuboid_backward_input_bytecode"
+"stub_complex64_ndarray_conv_cuboid_backward_input_native"
 
 
 external owl_float32_ndarray_transpose : ('a, 'b) owl_arr -> ('a, 'b) owl_arr -> (int32, int32_elt) owl_arr -> (int32, int32_elt) owl_arr -> unit = "stub_float32_ndarray_transpose"

--- a/src/owl/core/owl_ndarray_conv_impl.c
+++ b/src/owl/core/owl_ndarray_conv_impl.c
@@ -43,6 +43,8 @@ value FUN_NATIVE (spatial) (
   const int output_crb = output_rows * output_cols * batches;
   const int kernel_cri = kernel_cols * kernel_rows * in_channel;
 
+  INIT;
+
   TYPE *inpt2d = (TYPE *) calloc(kernel_cri * output_crb, sizeof(TYPE));
   if (inpt2d == NULL) exit(1);
 
@@ -85,9 +87,9 @@ value FUN_NATIVE (spatial) (
   }
 
   GEMM(CblasRowMajor, CblasNoTrans, CblasNoTrans,
-    output_crb, out_channel, kernel_cri, 1,
+    output_crb, out_channel, kernel_cri, ALPHA,
     inpt2d, kernel_cri, kernel_ptr, out_channel,
-    0, output_ptr, out_channel);
+    BETA, output_ptr, out_channel);
 
   free(inpt2d);
 
@@ -141,6 +143,8 @@ value FUN_NATIVE (spatial_backward_kernel) (
   const int output_crb = output_rows * output_cols * batches;
   const int kernel_cri = kernel_cols * kernel_rows * in_channel;
 
+  INIT;
+
   TYPE *inpt2d = (TYPE *) calloc(kernel_cri * output_crb, sizeof(TYPE));
   if (inpt2d == NULL) exit(1);
   TYPE *kern2d = (TYPE *) calloc(kernel_cri * out_channel, sizeof(TYPE));
@@ -184,9 +188,9 @@ value FUN_NATIVE (spatial_backward_kernel) (
   }
 
   GEMM(CblasRowMajor, CblasTrans, CblasNoTrans,
-    out_channel, kernel_cri, output_crb, 1,
+    out_channel, kernel_cri, output_crb, ALPHA,
     output_ptr, out_channel, inpt2d, kernel_cri,
-    0, kern2d, kernel_cri);
+    BETA, kern2d, kernel_cri);
 
   int cnt = 0;
   for (int j = 0; j < kernel_cri; ++j) {
@@ -246,6 +250,8 @@ value FUN_NATIVE (spatial_backward_input) (
   const int output_crb = output_rows * output_cols * batches;
   const int kernel_cri = kernel_cols * kernel_rows * in_channel;
 
+  INIT;
+
   TYPE *inpt2d = (TYPE *) calloc(kernel_cri * output_crb, sizeof(TYPE));
   if (inpt2d == NULL) exit(1);
 
@@ -259,9 +265,9 @@ value FUN_NATIVE (spatial_backward_input) (
   if (p_left < 0) p_left = 0;
 
   GEMM(CblasRowMajor, CblasNoTrans, CblasTrans,
-    output_crb, kernel_cri, out_channel, 1,
+    output_crb, kernel_cri, out_channel, ALPHA,
     output_ptr, out_channel, kernel_ptr, out_channel,
-    0, inpt2d, kernel_cri);
+    BETA, inpt2d, kernel_cri);
 
   for (int i = 0; i < output_crb; ++i) {
     int bt = i / output_cr;
@@ -348,6 +354,8 @@ value FUN_NATIVE (cuboid) (
   const int output_drcb = output_dpts * output_rows * output_cols * batches;
   const int kernel_idrc = in_channel  * kernel_dpts * kernel_rows * kernel_cols;
 
+  INIT;
+
   TYPE *inpt2d = (TYPE *) calloc(kernel_idrc * output_drcb, sizeof(TYPE));
   if (inpt2d == NULL) exit(1);
 
@@ -402,9 +410,9 @@ value FUN_NATIVE (cuboid) (
   }
 
   GEMM(CblasRowMajor, CblasNoTrans, CblasNoTrans,
-    output_drcb, out_channel, kernel_idrc, 1,
+    output_drcb, out_channel, kernel_idrc, ALPHA,
     inpt2d, kernel_idrc, kernel_ptr, out_channel,
-    0, output_ptr, out_channel);
+    BETA, output_ptr, out_channel);
 
   free(inpt2d);
 
@@ -462,6 +470,8 @@ value FUN_NATIVE (cuboid_backward_kernel) (
   const int output_drcb = output_dpts * output_rows * output_cols * batches;
   const int kernel_idrc = in_channel  * kernel_dpts * kernel_rows * kernel_cols;
 
+  INIT;
+
   TYPE *inpt2d = (TYPE *) calloc(kernel_idrc * output_drcb, sizeof(TYPE));
   if (inpt2d == NULL) exit(1);
   TYPE *kern2d = (TYPE *) calloc(kernel_idrc * out_channel, sizeof(TYPE));
@@ -514,9 +524,9 @@ value FUN_NATIVE (cuboid_backward_kernel) (
   }
 
   GEMM(CblasRowMajor, CblasTrans, CblasNoTrans,
-    out_channel, kernel_idrc, output_drcb, 1,
+    out_channel, kernel_idrc, output_drcb, ALPHA,
     output_ptr, out_channel, inpt2d, kernel_idrc,
-    0, kern2d, kernel_idrc);
+    BETA, kern2d, kernel_idrc);
 
   int cnt = 0;
   for (int j = 0; j < kernel_idrc; ++j) {
@@ -581,6 +591,8 @@ value FUN_NATIVE (cuboid_backward_input) (
   const int output_drcb = output_dpts * output_rows * output_cols * batches;
   const int kernel_idrc = in_channel  * kernel_dpts * kernel_rows * kernel_cols;
 
+  INIT;
+
   TYPE *inpt2d = (TYPE *) calloc(kernel_idrc * output_drcb, sizeof(TYPE));
   if (inpt2d == NULL) exit(1);
 
@@ -595,9 +607,9 @@ value FUN_NATIVE (cuboid_backward_input) (
   pd = pad_dpts / 2; if (pd < 0) pd = 0;
 
   GEMM(CblasRowMajor, CblasNoTrans, CblasTrans,
-    output_drcb, kernel_idrc, out_channel, 1,
+    output_drcb, kernel_idrc, out_channel, ALPHA,
     output_ptr, out_channel, kernel_ptr, out_channel,
-    0, inpt2d, kernel_idrc);
+    BETA, inpt2d, kernel_idrc);
 
   for (int i = 0; i < output_drcb; ++i) {
     int bt  = i / output_drc;

--- a/src/owl/core/owl_ndarray_conv_stub.c
+++ b/src/owl/core/owl_ndarray_conv_stub.c
@@ -16,11 +16,16 @@
 #define FUN_NATIVE(dim) stub_float32_ndarray_conv ## _ ## dim  ## _ ## native
 #define FUN_BYTE(dim) stub_float32_ndarray_conv ## _ ## dim  ## _ ## bytecode
 #define TYPE float
+#define INIT
+#define ALPHA 1.
+#define BETA 0.
 #define GEMM cblas_sgemm
 #include "owl_ndarray_conv_impl.c"
-#undef TYPE
 #undef GEMM
-#undef INITACC
+#undef BETA
+#undef ALPHA
+#undef INIT
+#undef TYPE
 #undef FUN_BYTE
 #undef FUN_NATIVE
 
@@ -28,11 +33,50 @@
 #define FUN_NATIVE(dim) stub_float64_ndarray_conv ## _ ## dim  ## _ ## native
 #define FUN_BYTE(dim) stub_float64_ndarray_conv ## _ ## dim  ## _ ## bytecode
 #define TYPE double
+#define INIT
+#define ALPHA 1.
+#define BETA 0.
 #define GEMM cblas_dgemm
 #include "owl_ndarray_conv_impl.c"
-#undef TYPE
 #undef GEMM
-#undef INITACC
+#undef BETA
+#undef ALPHA
+#undef INIT
+#undef TYPE
+#undef FUN_BYTE
+#undef FUN_NATIVE
+
+
+#define FUN_NATIVE(dim) stub_complex32_ndarray_conv ## _ ## dim  ## _ ## native
+#define FUN_BYTE(dim) stub_complex32_ndarray_conv ## _ ## dim  ## _ ## bytecode
+#define TYPE _Complex float
+#define INIT _Complex float alpha = 1., beta = 0.
+#define ALPHA &alpha
+#define BETA &beta
+#define GEMM cblas_cgemm
+#include "owl_ndarray_conv_impl.c"
+#undef GEMM
+#undef BETA
+#undef ALPHA
+#undef INIT
+#undef TYPE
+#undef FUN_BYTE
+#undef FUN_NATIVE
+
+
+#define FUN_NATIVE(dim) stub_complex64_ndarray_conv ## _ ## dim  ## _ ## native
+#define FUN_BYTE(dim) stub_complex64_ndarray_conv ## _ ## dim  ## _ ## bytecode
+#define TYPE _Complex double
+#define INIT _Complex double alpha = 1., beta = 0.
+#define ALPHA &alpha
+#define BETA &beta
+#define GEMM cblas_zgemm
+#include "owl_ndarray_conv_impl.c"
+#undef GEMM
+#undef BETA
+#undef ALPHA
+#undef INIT
+#undef TYPE
 #undef FUN_BYTE
 #undef FUN_NATIVE
 

--- a/src/owl/dense/owl_dense_common.ml
+++ b/src/owl/dense/owl_dense_common.ml
@@ -176,31 +176,43 @@ let _owl_gaussian_fun : type a b. (a, b) kind -> (float -> a) = function
 let _owl_spatial_conv : type a b . (a, b) kind -> (a, b) owl_arr_op22 = function
   | Float32   -> Owl_ndarray.owl_float32_ndarray_conv_spatial
   | Float64   -> Owl_ndarray.owl_float64_ndarray_conv_spatial
+  | Complex32 -> Owl_ndarray.owl_complex32_ndarray_conv_spatial
+  | Complex64 -> Owl_ndarray.owl_complex64_ndarray_conv_spatial
   | _         -> failwith "_owl_spatial_conv: unsupported operation"
 
 let _owl_spatial_conv_backward_input : type a b . (a, b) kind -> (a, b) owl_arr_op23 = function
   | Float32   -> Owl_ndarray.owl_float32_ndarray_conv_spatial_backward_input
   | Float64   -> Owl_ndarray.owl_float64_ndarray_conv_spatial_backward_input
+  | Complex32 -> Owl_ndarray.owl_complex32_ndarray_conv_spatial_backward_input
+  | Complex64 -> Owl_ndarray.owl_complex64_ndarray_conv_spatial_backward_input
   | _         -> failwith "_owl_spatial_conv_backward_input: unsupported operation"
 
 let _owl_spatial_conv_backward_kernel : type a b . (a, b) kind -> (a, b) owl_arr_op23 = function
   | Float32   -> Owl_ndarray.owl_float32_ndarray_conv_spatial_backward_kernel
   | Float64   -> Owl_ndarray.owl_float64_ndarray_conv_spatial_backward_kernel
+  | Complex32 -> Owl_ndarray.owl_complex32_ndarray_conv_spatial_backward_kernel
+  | Complex64 -> Owl_ndarray.owl_complex64_ndarray_conv_spatial_backward_kernel
   | _         -> failwith "_owl_spatial_conv_backward_kernel: unsupported operation"
 
 let _owl_cuboid_conv : type a b . (a, b) kind -> (a, b) owl_arr_op24 = function
   | Float32   -> Owl_ndarray.owl_float32_ndarray_conv_cuboid
   | Float64   -> Owl_ndarray.owl_float64_ndarray_conv_cuboid
+  | Complex32 -> Owl_ndarray.owl_complex32_ndarray_conv_cuboid
+  | Complex64 -> Owl_ndarray.owl_complex64_ndarray_conv_cuboid
   | _         -> failwith "_owl_cuboid_conv: unsupported operation"
 
 let _owl_cuboid_conv_backward_input : type a b . (a, b) kind -> (a, b) owl_arr_op25 = function
   | Float32   -> Owl_ndarray.owl_float32_ndarray_conv_cuboid_backward_input
   | Float64   -> Owl_ndarray.owl_float64_ndarray_conv_cuboid_backward_input
+  | Complex32 -> Owl_ndarray.owl_complex32_ndarray_conv_cuboid_backward_input
+  | Complex64 -> Owl_ndarray.owl_complex64_ndarray_conv_cuboid_backward_input
   | _         -> failwith "_owl_cuboid_conv_backward_input: unsupported operation"
 
 let _owl_cuboid_conv_backward_kernel : type a b . (a, b) kind -> (a, b) owl_arr_op25 = function
   | Float32   -> Owl_ndarray.owl_float32_ndarray_conv_cuboid_backward_kernel
   | Float64   -> Owl_ndarray.owl_float64_ndarray_conv_cuboid_backward_kernel
+  | Complex32 -> Owl_ndarray.owl_complex32_ndarray_conv_cuboid_backward_kernel
+  | Complex64 -> Owl_ndarray.owl_complex64_ndarray_conv_cuboid_backward_kernel
   | _         -> failwith "_owl_cuboid_conv_backward_kernel: unsupported operation"
 
 let _owl_spatial_max_pooling : type a b . (a, b) kind -> (a, b) owl_arr_op26 = function


### PR DESCRIPTION
This PR adds supports of complex number for `conv` function in Owl. 

@jzstark please can you have a look to confirm the added code is consistent with your implementation? Many thanks. Also, it would be nice if you can also test a couple of very simple examples with complex number?